### PR TITLE
Storage name must match with response storage

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -207,11 +207,11 @@ extension Request {
     // Warning: The storage key has to be in sync with Zewo.HTTP's upgrade property.
     var didUpgrade: DidUpgrade? {
         get {
-            return storage["request-upgrade"] as? DidUpgrade
+            return storage["request-connection-upgrade"] as? DidUpgrade
         }
 
         set(didUpgrade) {
-            storage["request-upgrade"] = didUpgrade
+            storage["request-connection-upgrade"] = didUpgrade
         }
     }
 


### PR DESCRIPTION
# problem

response storage name and request storage name did not match
storage["request-upgrade"]
storage["response-connection-upgrade"]
all request has same and all response has same so program works fine.
# fix

Changing request storage name to match response storage name.
This should be changed in same time with 3 packages.
- HTTP
- HTTPClient
- HTTPSClient
