### PR TITLE
[FIX] Add port to header Host only if it is different than 80 or 443

### DIFF
--- a/Sources/HTTPClient/Client.swift
+++ b/Sources/HTTPClient/Client.swift
@@ -152,7 +152,11 @@ extension Client {
     }
 
     private func addHeaders(to request: inout Request) {
-        request.host = request.host ?? "\(host):\(port)"
+        request.host = request.host ?? host
+        
+        if port != 80 && port != 443 {
+            request.host = request.host ?? "\(host):\(port)"
+        }
 
         if addUserAgent {
             request.userAgent = request.userAgent ?? "Zewo"


### PR DESCRIPTION
Issue:
https://github.com/Zewo/Zewo/issues/224

Reference:
http://stackoverflow.com/questions/3364144/is-port-number-required-in-http-host-header-parameter